### PR TITLE
group peek improvements

### DIFF
--- a/cmd/kaf/group.go
+++ b/cmd/kaf/group.go
@@ -66,6 +66,7 @@ func init() {
 	groupPeekCmd.Flags().Int32SliceVarP(&flagPeekPartitions, "partitions", "p", []int32{}, "Partitions to peek from")
 	groupPeekCmd.Flags().Int64VarP(&flagPeekBefore, "before", "B", 0, "Number of messages to peek before current offset")
 	groupPeekCmd.Flags().Int64VarP(&flagPeekAfter, "after", "A", 0, "Number of messages to peek after current offset")
+	groupPeekCmd.Flags().VarP(&outputFormat, "output", "o", "Set output format messages: default, raw (without key or prettified JSON), json")
 
 	groupDescribeCmd.Flags().BoolVar(&flagNoMembers, "no-members", false, "Hide members section of the output")
 	groupDescribeCmd.Flags().StringSliceVarP(&flagDescribeTopics, "topic", "t", []string{}, "topics to display for the group. defaults to all topics.")
@@ -381,6 +382,8 @@ var groupPeekCmd = &cobra.Command{
 			fmt.Printf("Group %v not found.\n", args[0])
 			return
 		}
+
+		schemaCache = getSchemaCache()
 
 		peekPartitions := make(map[int32]struct{})
 		for _, partition := range flagPeekPartitions {


### PR DESCRIPTION
This code doesn't feel very well organized but 🤷 works like a charm.

## Usage

```
❯ mkaf group peek -h
Peek messages from consumer group offset

Usage:
  kaf group peek [flags]

Flags:
  -A, --after int               Number of messages to peek after current offset
  -B, --before int              Number of messages to peek before current offset
  -h, --help                    help for peek
  -o, --output OutputFormat     Set output format messages: default, raw (without key or prettified JSON), json (default default)
  -p, --partitions int32Slice   Partitions to peek from (default [])
  -t, --topics strings          Topics to peek from
```

## Output

### json

`mkaf --cluster staging-dedicated group peek matcher-default --partitions 0,1,3 --output json -A 1 -B 1`
```jsonl
{"headers":[{"Key":"cmVjZWl2ZWRfYXQ=","Value":"MjAyNS0wMy0wNVQwMDozNTo1Ni40NzI3NjQ0OTVa"},{"Key":"Y29ob3J0","Value":"dXNhZ2UtZXZlbnRzLWRlZHVwbGljYXRlZC1kZWZhdWx0"}],"key":{"client_id":"329557c9-b2e9-4df0-9c6e-642cb9256a52","transaction_id":"9jX9Ti/7GLesXAakha6heWsFqcvhx+rDVoAuA17Lp2M="},"offset":1047901367,"partition":0,"payload":{"client_id":"329557c9-b2e9-4df0-9c6e-642cb9256a52","customer_id":"462b838b-1582-4100-816e-f6c07bb604fe","environment_type":{"string":"PRODUCTION"},"event_id":{"string":"af6a7d1a-cb19-4cfd-bc34-1e104926ded2"},"event_type":"INGEST","jws_data":null,"properties":{"__metronome_original_transaction_id":{"string":"req_6a66afac677431b83b2ffd3b0bbbf309:72:0:0:0:0"}},"timestamp":"2025-03-05T00:35:56.051Z","transaction_id":"9jX9Ti/7GLesXAakha6heWsFqcvhx+rDVoAuA17Lp2M="},"timestamp":"2025-03-05T02:35:56.472+02:00"}
{"headers":[{"Key":"cmVjZWl2ZWRfYXQ=","Value":"MjAyNS0wMy0wNVQwMDozNTo1Ni40OTQwNzY0Nzda"},{"Key":"Y29ob3J0","Value":"dXNhZ2UtZXZlbnRzLWRlZHVwbGljYXRlZC1kZWZhdWx0"}],"key":{"client_id":"b5f46ed6-0e1b-498a-a9c9-c4b92974af24","transaction_id":"PV6zAeVI+DJ5QfcLcDVcwFRsmmnl6+Y0xNZ3WcPYVDI="},"offset":1047901368,"partition":0,"payload":{"client_id":"b5f46ed6-0e1b-498a-a9c9-c4b92974af24","customer_id":"462b838b-1582-4100-816e-f6c07bb604fe","environment_type":{"string":"PRODUCTION"},"event_id":{"string":"137b3d2d-f777-486b-9312-d11553f119ae"},"event_type":"INGEST","jws_data":null,"properties":{"__metronome_original_transaction_id":{"string":"req_097fff240e7102a159dbe7fcb74ff3d4:3339:0:0:210:0"}},"timestamp":"2025-03-05T00:35:56.090Z","transaction_id":"PV6zAeVI+DJ5QfcLcDVcwFRsmmnl6+Y0xNZ3WcPYVDI="},"timestamp":"2025-03-05T02:35:56.494+02:00"}
{"headers":[{"Key":"cmVjZWl2ZWRfYXQ=","Value":"MjAyNS0wMy0wNVQwMDozNTo1Ni4yNTg4MjEyNjJa"},{"Key":"Y29ob3J0","Value":"dXNhZ2UtZXZlbnRzLWRlZHVwbGljYXRlZC1kZWZhdWx0"}],"key":{"client_id":"314fce02-255a-4378-9c82-fbdad039d66b","transaction_id":"knL0E/a5PopkEK6k3G6tvuOPDxLV0LWyoy/tjK1J4PQ="},"offset":1047945983,"partition":3,"payload":{"client_id":"314fce02-255a-4378-9c82-fbdad039d66b","customer_id":"462b838b-1582-4100-816e-f6c07bb604fe","environment_type":{"string":"PRODUCTION"},"event_id":{"string":"49278f57-3984-4f9d-a8f9-bdfcaebd5ba5"},"event_type":"INGEST","jws_data":null,"properties":{"__metronome_original_transaction_id":{"string":"req_b3f8401aec49471d52607efd17db0f1d:2707:0:0:1:0"}},"timestamp":"2025-03-05T00:35:55.670Z","transaction_id":"knL0E/a5PopkEK6k3G6tvuOPDxLV0LWyoy/tjK1J4PQ="},"timestamp":"2025-03-05T02:35:56.258+02:00"}
{"headers":[{"Key":"cmVjZWl2ZWRfYXQ=","Value":"MjAyNS0wMy0wNVQwMDozNTo1Ni4yNTkwNjk5MzRa"},{"Key":"Y29ob3J0","Value":"dXNhZ2UtZXZlbnRzLWRlZHVwbGljYXRlZC1kZWZhdWx0"}],"key":{"client_id":"aeb8e5ee-16a7-4b9d-88e1-2294a8e0697c","transaction_id":"MD/QxfDmHnMZ174qZJHSRNv84WrcSjdC/8hIVMDMhUU="},"offset":1047945984,"partition":3,"payload":{"client_id":"aeb8e5ee-16a7-4b9d-88e1-2294a8e0697c","customer_id":"462b838b-1582-4100-816e-f6c07bb604fe","environment_type":{"string":"PRODUCTION"},"event_id":{"string":"7029dafd-b3d7-401a-864d-036a188d4d89"},"event_type":"INGEST","jws_data":null,"properties":{"__metronome_original_transaction_id":{"string":"req_a08a27c91d478b7195a1e8906fd39f6e:1013:0:0:62:0"}},"timestamp":"2025-03-05T00:35:56.087Z","transaction_id":"MD/QxfDmHnMZ174qZJHSRNv84WrcSjdC/8hIVMDMhUU="},"timestamp":"2025-03-05T02:35:56.259+02:00"}
{"headers":[{"Key":"cmVjZWl2ZWRfYXQ=","Value":"MjAyNS0wMy0wNVQwMDozNTo1Ni40OTA0NjUxNTVa"},{"Key":"Y29ob3J0","Value":"dXNhZ2UtZXZlbnRzLWRlZHVwbGljYXRlZC1kZWZhdWx0"}],"key":{"client_id":"314fce02-255a-4378-9c82-fbdad039d66b","transaction_id":"clJHa6eZSpqU2xzT0UKljDUmyYHzTlAShSTnujXAa1o="},"offset":1047707471,"partition":1,"payload":{"client_id":"314fce02-255a-4378-9c82-fbdad039d66b","customer_id":"462b838b-1582-4100-816e-f6c07bb604fe","environment_type":{"string":"PRODUCTION"},"event_id":{"string":"8bf23f9c-776d-4f9a-bc73-a89bbe136941"},"event_type":"INGEST","jws_data":null,"properties":{"__metronome_original_transaction_id":{"string":"req_ef66cdba75f98984c141f9febc868054:249:0:0:55:0"}},"timestamp":"2025-03-05T00:35:55.935Z","transaction_id":"clJHa6eZSpqU2xzT0UKljDUmyYHzTlAShSTnujXAa1o="},"timestamp":"2025-03-05T02:35:56.49+02:00"}
{"headers":[{"Key":"cmVjZWl2ZWRfYXQ=","Value":"MjAyNS0wMy0wNVQwMDozNTo1Ni43MTM2NjQ0MTVa"},{"Key":"Y29ob3J0","Value":"dXNhZ2UtZXZlbnRzLWRlZHVwbGljYXRlZC1kZWZhdWx0"}],"key":{"client_id":"3e260554-bd85-48aa-9fcb-3f5b5434f6ab","transaction_id":"4qTr/81LA7M08ao8P92j4Clh0A7SIamqoKfLnSzWrDQ="},"offset":1047707472,"partition":1,"payload":{"client_id":"3e260554-bd85-48aa-9fcb-3f5b5434f6ab","customer_id":"462b838b-1582-4100-816e-f6c07bb604fe","environment_type":{"string":"PRODUCTION"},"event_id":{"string":"fb17eafc-35b2-4943-9341-a6d1b2924581"},"event_type":"INGEST","jws_data":null,"properties":{"__metronome_original_transaction_id":{"string":"req_9d867bda3084e761dc75d22728cd4488:29:0:0:0:0"}},"timestamp":"2025-03-05T00:35:56.115Z","transaction_id":"4qTr/81LA7M08ao8P92j4Clh0A7SIamqoKfLnSzWrDQ="},"timestamp":"2025-03-05T02:35:56.713+02:00"}
```

### raw

`mkaf --cluster staging-dedicated group peek matcher-default --partitions 0 --output raw`
```json
{"client_id":"b5f46ed6-0e1b-498a-a9c9-c4b92974af24","event_id":{"string":"13a47941-f2ad-49e4-82fe-be99140749ef"},"event_type":"INGEST","timestamp":"2025-03-05T00:33:19.091Z","customer_id":"462b838b-1582-4100-816e-f6c07bb604fe","properties":{"__metronome_original_transaction_id":{"string":"req_1468d01eec3f6355147eb27a2b6de747:657:0:0:13:0"}},"jws_data":null,"transaction_id":"n6Kyg8vJEueIBu9dwQDEUCzF7yljovH1QEFQarUE8s4=","environment_type":{"string":"PRODUCTION"}}
```

### default

`mkaf --cluster staging-dedicated group peek matcher-default --partitions 0 --output default`
```
Headers:
             Key: received_at   Value: 2025-03-05T00:34:38.968798569Z
             Key: cohort        Value: usage-events-deduplicated-default
Key:         { "client_id": "b03820cc-e29a-473b-87f1-28e0ae33c415", "transaction_id": "b/jdF5FpqlaOJfGxUap84oozgfmpGKKm51VU2gypq+k=" }
Partition:   0
Offset:      1047893911
Timestamp:   2025-03-05 02:34:38.968 +0200 SAST
{
  "client_id": "b03820cc-e29a-473b-87f1-28e0ae33c415",
  "customer_id": "462b838b-1582-4100-816e-f6c07bb604fe",
  "environment_type": {
    "string": "PRODUCTION"
  },
  "event_id": {
    "string": "39ad0a8d-4713-4aec-8b8b-0ee005e4ba1c"
  },
  "event_type": "INGEST",
  "jws_data": null,
  "properties": {
    "__metronome_original_transaction_id": {
      "string": "req_83086e975b8d77e8940761b87b9f5886:14:0:0:0:0"
    }
  },
  "timestamp": "2025-03-05T00:34:38.611Z",
  "transaction_id": "b/jdF5FpqlaOJfGxUap84oozgfmpGKKm51VU2gypq+k="
}
```